### PR TITLE
Disk Usage calculation changed to use Java API

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/GetSpaceUsed.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/GetSpaceUsed.java
@@ -84,7 +84,7 @@ public interface GetSpaceUsed {
       if (Shell.WINDOWS) {
         result = WindowsGetSpaceUsed.class;
       } else {
-        result = DU.class;
+        result = WindowsGetSpaceUsed.class;
       }
       if (conf == null) {
         return result;
@@ -158,7 +158,7 @@ public interface GetSpaceUsed {
         if (Shell.WINDOWS) {
           getSpaceUsed = new WindowsGetSpaceUsed(this);
         } else {
-          getSpaceUsed = new DU(this);
+          getSpaceUsed = new WindowsGetSpaceUsed(this);
         }
       }
       // Call init after classes constructors have finished.


### PR DESCRIPTION
Earlier it was using shell script 'du -sk'.
This implementation is more platform independent
